### PR TITLE
Add CI workflow to automate testing for compilation on gcc C++17 standard, closes #2

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,23 @@
+name: Build C++
+
+on:
+  push:
+    branches: [ main, add-ci ]
+  pull_request:
+    branches: [ main, add-ci ]
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y -f build-essential g++ cmake
+  build:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build project
+        run: g++ main.cpp -std=c++17 -o run

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![C++ CI](https://github.com/Tabris05/ColorPalette/actions/workflows/actions.yml/badge.svg)](https://github.com/Tabris05/ColorPalette/actions/workflows/actions.yml)
 # ColorPalette
 
 This is a simple C++ program for managing a collection or palette of RGB colors.


### PR DESCRIPTION
Added a github actions workflow to automatically test for compilation success on the G++ compiler using the C++17 standard, as well as the corresponding badge in the README.md file.